### PR TITLE
Haneef connect CLPs

### DIFF
--- a/gui/src/atoms/Coin.tsx
+++ b/gui/src/atoms/Coin.tsx
@@ -25,9 +25,56 @@ const Image = styled<{ big: boolean, onClick?: ((event: React.MouseEvent<HTMLIma
   `}
 `
 
+const Placeholder = styled<{
+  big: boolean,
+  selected: boolean,
+  onClick?: ((event: React.MouseEvent<HTMLDivElement>) => void),
+}, 'div'>('div')`
+  height: 50px;
+  width: 50px;
+  vertical-align: middle;
+  display: inline-block;
+  border-radius: 50px;
+  background: #314151;
+  color: #586e81;
+  text-align: center;
+  padding-top: 16px;
+  box-sizing: border-box;
+  font-family: 'Exo 2';
+  font-size: 14px;
+  ${props => props.big && css`
+    height: 80px;
+    width: 80px;
+    margin-left: 15px;
+    margin-right: 15px;
+    border-radius: 80px;
+    font-size: 20px;
+    padding-top: 27px;
+  `}
+  ${props => props.onClick && css`
+    cursor: pointer;
+  `}
+  ${props => props.selected && css`
+    background: #fff;
+  `}
+`
+
 export const Coin = ({ selected, type, big, style, onClick }: IProps) => {
   const coinData = tokens[type] ? tokens[type] : tokens.BTC
   const coinImage = selected ? coinData.colorImage : coinData.greyImage
+
+  if (!coinImage) {
+    return (
+      <Placeholder
+        big={Boolean(big)}
+        selected={selected}
+        onClick={onClick}
+        style={style}
+      >
+        {coinData.denom}
+      </Placeholder>
+    )
+  }
 
   return (
     <Image

--- a/gui/src/atoms/Coin.tsx
+++ b/gui/src/atoms/Coin.tsx
@@ -70,6 +70,7 @@ export const Coin = ({ selected, type, big, style, onClick }: IProps) => {
         selected={selected}
         onClick={onClick}
         style={style}
+        tabIndex={onClick ? 0 : undefined}
       >
         {coinData.denom}
       </Placeholder>

--- a/gui/src/helpers/tokens.ts
+++ b/gui/src/helpers/tokens.ts
@@ -2,6 +2,12 @@
  * List of all tokens and associated useful info
  */
 const tokens = {
+  'ADA': {
+    colorImage: null,
+    denom: 'ADA',
+    greyImage: null,
+    name: 'ADA',
+  },
   'BCH': {
     colorImage: {
       '1x': require('../images/coins/coins_bitcoincash_color.png'),
@@ -26,6 +32,12 @@ const tokens = {
     },
     name: 'Bitcoin',
   },
+  'CAN': {
+    colorImage: null,
+    denom: 'CAN',
+    greyImage: null,
+    name: 'CanYaCoin',
+  },
   'DASH': {
     colorImage: {
       '1x': require('../images/coins/coins_dash_color.png'),
@@ -37,6 +49,12 @@ const tokens = {
       '2x': require('../images/coins/coins_dash_grey@2x.png'),
     },
     name: 'Dash',
+  },
+  'EOS': {
+    colorImage: null,
+    denom: 'EOS',
+    greyImage: null,
+    name: 'EOS',
   },
   'ETH': {
     colorImage: {
@@ -50,6 +68,12 @@ const tokens = {
     },
     name: 'Ethereum',
   },
+  'LOKI': {
+    colorImage: null,
+    denom: 'LOKI',
+    greyImage: null,
+    name: 'Loki',
+  },
   'LTC': {
     colorImage: {
       '1x': require('../images/coins/coins_litecoin_color.png'),
@@ -61,6 +85,12 @@ const tokens = {
       '2x': require('../images/coins/coins_litecoin_grey@2x.png'),
     },
     name: 'Litecoin',
+  },
+  'NEO': {
+    colorImage: null,
+    denom: 'NEO',
+    greyImage: null,
+    name: 'NEO',
   },
   'USDT': {
     colorImage: {
@@ -74,6 +104,12 @@ const tokens = {
     },
     name: 'USD Tether',
   },
+  'XEM': {
+    colorImage: null,
+    denom: 'XEM',
+    greyImage: null,
+    name: 'New Economy Movement',
+  },
   'XMR': {
     colorImage: {
       '1x': require('../images/coins/coins_monero_color.png'),
@@ -85,6 +121,12 @@ const tokens = {
       '2x': require('../images/coins/coins_monero_grey@2x.png'),
     },
     name: 'Monero',
+  },
+  'XRP': {
+    colorImage: null,
+    denom: 'XRP',
+    greyImage: null,
+    name: 'Ripple',
   },
   'ZIL': {
     colorImage: {

--- a/gui/src/helpers/tokens.ts
+++ b/gui/src/helpers/tokens.ts
@@ -92,6 +92,12 @@ const tokens = {
     greyImage: null,
     name: 'NEO',
   },
+  'RUNE': {
+    colorImage: null,
+    denom: 'RUNE',
+    greyImage: null,
+    name: 'Rune',
+  },
   'USDT': {
     colorImage: {
       '1x': require('../images/coins/coins_tether_color.png'),

--- a/gui/src/organisms/AccountSetup.tsx
+++ b/gui/src/organisms/AccountSetup.tsx
@@ -8,7 +8,8 @@ import { Header } from '../atoms/Header'
 import { Input } from '../atoms/Input'
 import { Label } from '../atoms/Label'
 import { Row } from '../atoms/Row'
-import { ICoin, IStore } from '../store/Store'
+import { ICoin } from '../store/Coin'
+import { IStore } from '../store/Store'
 
 interface IProps {
   store?: IStore

--- a/gui/src/organisms/CreateSwap.tsx
+++ b/gui/src/organisms/CreateSwap.tsx
@@ -91,7 +91,7 @@ export class CreateSwap extends React.Component<IProps, IState> {
       selectedExchangeAmount,
     } = this.state
 
-    const { getTokenPriceInUsdt, clps, wallet } = this.props.store!
+    const { getTokenPriceInUsdt, getTokenExchangeRate, clps, wallet } = this.props.store!
 
     let exchangeTokensToRender = clps.map(pool => ({ denom: pool.denom }))
     exchangeTokensToRender.push({ denom: 'RUNE' })
@@ -113,8 +113,9 @@ export class CreateSwap extends React.Component<IProps, IState> {
       return token.denom.includes(searchTerm) || tokenName.includes(searchTerm) || Number(searchTerm) === index
     })
 
-    // TODO replace this with real data from CLPs
-    const tokenExchangeRate = 3.2
+    const tokenExchangeRate = selectedExchangeToken === null || selectedReceiveToken === null
+      ? null
+      : getTokenExchangeRate(selectedExchangeToken, selectedReceiveToken)
 
     // Can't exchange more than you have in your wallet
     const maxExchangeAmount = selectedExchangeAmount || 0
@@ -203,10 +204,10 @@ export class CreateSwap extends React.Component<IProps, IState> {
                   exchangeType={selectedExchangeToken}
                   receiveType={selectedReceiveToken}
                   exchangeAmount={totalExchangeAmount}
-                  receiveAmount={totalExchangeAmount * tokenExchangeRate}
+                  receiveAmount={totalExchangeAmount * (tokenExchangeRate || 0)}
                   dollarsExchangeAmount={getTokenPriceInUsdt(totalExchangeAmount, selectedExchangeToken)}
                   dollarsReceiveAmount={
-                    getTokenPriceInUsdt(totalExchangeAmount * tokenExchangeRate, selectedReceiveToken)
+                    getTokenPriceInUsdt(totalExchangeAmount * (tokenExchangeRate || 0), selectedReceiveToken)
                   }
                 />
               )}

--- a/gui/src/organisms/CreateSwap.tsx
+++ b/gui/src/organisms/CreateSwap.tsx
@@ -43,6 +43,9 @@ export class CreateSwap extends React.Component<IProps, IState> {
     // Fetch token prices every 5 seconds
     props.store!.fetchPrices()
     setInterval(() => props.store!.fetchPrices(), 5000)
+
+    // Fetch CLPs
+    props.store!.fetchCLPs()
   }
 
   public handleExchangeTokenClick = (selectedExchangeToken:string, selectedExchangeAmount:number) => () => {
@@ -88,38 +91,17 @@ export class CreateSwap extends React.Component<IProps, IState> {
       selectedExchangeAmount,
     } = this.state
 
-    const { getTokenPriceInUsdt } = this.props.store!
+    const { getTokenPriceInUsdt, clps, wallet } = this.props.store!
 
-    // TODO replace with real wallet info
-    const walletTokens = [
-      {
-        amount: '0.1',
-        denom: 'BTC',
-      },
-      {
-        amount: '10',
-        denom: 'ETH',
-      },
-      {
-        amount: '10',
-        denom: 'LTC',
-      },
-      {
-        amount: '100',
-        denom: 'XMR',
-      },
-    ]
+    let exchangeTokensToRender = clps.map(pool => ({ denom: pool.denom }))
+    exchangeTokensToRender.push({ denom: 'RUNE' })
 
-    const exchangeTokensToRender = [
-      { denom: 'BTC' },
-      { denom: 'ETH' },
-      { denom: 'LTC' },
-      { denom: 'XMR' },
-      { denom: 'DASH' },
-      // { denom: 'BCH' }, TODO uncomment when hard fork of BCH has been resolved
-      { denom: 'USDT' },
-      { denom: 'ZIL' },
-    ].filter((token, index) => {
+    exchangeTokensToRender = exchangeTokensToRender.filter((token, index) => {
+      // Exclude these tokens for now - they're not available in Binance's pricing API
+      if (token.denom === 'LOKI' || token.denom === 'CAN') {
+        return false
+      }
+
       if (tokenSearchTerm === '') {
         return true
       }
@@ -145,7 +127,7 @@ export class CreateSwap extends React.Component<IProps, IState> {
             <Header>
               Your Wallet
             </Header>
-            {walletTokens.map((token) => (
+            {wallet && wallet.coins.map((token) => (
               <CoinWrapper key={token.denom}>
                 <Coin
                   type={token.denom}

--- a/gui/src/organisms/Orderbook/View.tsx
+++ b/gui/src/organisms/Orderbook/View.tsx
@@ -4,7 +4,9 @@ import styled from 'styled-components'
 import { formatNum } from 'thorchain-info-common/build/helpers/formatNum'
 import { ValueColored } from '../../atoms/ValueColored'
 import { getInUsd } from '../../helpers/getInUsd'
-import { IOrder, IOrderbook, IPairOHLCV } from '../../store/Store'
+import { IOrder } from '../../store/Order'
+import { IOrderbook } from '../../store/Orderbook'
+import { IPairOHLCV } from '../../store/PairOHLCV'
 import bars from './bars.svg'
 
 interface IProps {

--- a/gui/src/organisms/PairInfoBar/View.tsx
+++ b/gui/src/organisms/PairInfoBar/View.tsx
@@ -5,7 +5,7 @@ import { formatNum } from 'thorchain-info-common/build/helpers/formatNum'
 import { formatPercent } from 'thorchain-info-common/build/helpers/formatPercent'
 import { ValueColored } from '../../atoms/ValueColored'
 import { getInUsd } from '../../helpers/getInUsd'
-import { IPair } from '../../store/Store'
+import { IPair } from '../../store/Pair'
 
 interface IProps {
   pairSelected: IPair

--- a/gui/src/organisms/PairsList/View.tsx
+++ b/gui/src/organisms/PairsList/View.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components'
 import { formatNum } from 'thorchain-info-common/build/helpers/formatNum'
 import { formatPercent } from 'thorchain-info-common/build/helpers/formatPercent'
 import { ValueColored } from '../../atoms/ValueColored'
-import { IPair, IStore } from '../../store/Store'
+import { IPair } from '../../store/Pair'
+import { IStore } from '../../store/Store'
 
 interface IProps {
   store: IStore

--- a/gui/src/organisms/TokenExchangeAmountDisplay.tsx
+++ b/gui/src/organisms/TokenExchangeAmountDisplay.tsx
@@ -157,25 +157,23 @@ export class TokenExchangeAmountDisplay extends React.Component<IProps, IState> 
             </InputRadioButton>
           </PercentageButtons>
         )}
-        {dollarsExchangeRate && (
-          <CalculatedAmounts>
-            <TokenAmountWrapper>
-              <InputAmount value={totalAmountString} onChange={this.handleTotalAmountChange}/>
-              <Denom>
-                {tokenData.denom}
-              </Denom>
-            </TokenAmountWrapper>
-            <Separator/>
-            <USDAmountWrapper>
-              <Amount>
-                ${formatNum(dollars)}
-              </Amount>
-              <Denom>
-                USD
-              </Denom>
-            </USDAmountWrapper>
-          </CalculatedAmounts>
-        )}
+        <CalculatedAmounts>
+          <TokenAmountWrapper>
+            <InputAmount value={totalAmountString} onChange={this.handleTotalAmountChange}/>
+            <Denom>
+              {tokenData.denom}
+            </Denom>
+          </TokenAmountWrapper>
+          <Separator/>
+          <USDAmountWrapper>
+            <Amount>
+              {dollarsExchangeRate ? `$${formatNum(dollars)}` : '?'}
+            </Amount>
+            <Denom>
+              USD
+            </Denom>
+          </USDAmountWrapper>
+        </CalculatedAmounts>
       </Wrapper>
     )
   }

--- a/gui/src/organisms/TokenReceiveAmountDisplay.tsx
+++ b/gui/src/organisms/TokenReceiveAmountDisplay.tsx
@@ -19,8 +19,8 @@ export const TokenReceiveAmountDisplay = ({
   receiveExchangeRate=1,
   receiveType,
 }: IProps) => {
-  const tokenData = tokens[type] ? tokens[type] : tokens.BTC
-  const receiveTokenData = tokens[receiveType] ? tokens[receiveType] : tokens.ETH
+  const tokenData = tokens[type]
+  const receiveTokenData = tokens[receiveType]
   const dollars = dollarsExchangeRate ? receiveExchangeRate * dollarsExchangeRate * amount : 0
   const receiveAmount = receiveExchangeRate * amount
 
@@ -33,34 +33,34 @@ export const TokenReceiveAmountDisplay = ({
         />
         <TokenInfo>
           <TokenName>{receiveTokenData.name} ({receiveTokenData.denom})</TokenName>
-          <TokenAmounts>
-            {formatNum(amount, 4)} {tokenData.denom}
-            {' '}={' '}
-            {formatNum(receiveAmount, 4)} {receiveTokenData.denom}
-          </TokenAmounts>
+          {tokenData && receiveTokenData && (
+            <TokenAmounts>
+              {formatNum(amount, 4)} {tokenData.denom}
+              {' '}={' '}
+              {formatNum(receiveAmount, 4)} {receiveTokenData.denom}
+            </TokenAmounts>
+          )}
         </TokenInfo>
       </TokenInfoWrapper>
-      {dollarsExchangeRate && (
-        <CalculatedAmounts>
-          <TokenAmountWrapper>
-            <Amount>
-              {formatNum(receiveAmount, 4)}
-            </Amount>
-            <Denom>
-              {receiveTokenData.denom}
-            </Denom>
-          </TokenAmountWrapper>
-          <Separator/>
-          <USDAmountWrapper>
-            <Amount>
-              ${formatNum(dollars)}
-            </Amount>
-            <Denom>
-              USD
-            </Denom>
-          </USDAmountWrapper>
-        </CalculatedAmounts>
-      )}
+      <CalculatedAmounts>
+        <TokenAmountWrapper>
+          <Amount>
+            {formatNum(receiveAmount, 4)}
+          </Amount>
+          <Denom>
+            {receiveTokenData.denom}
+          </Denom>
+        </TokenAmountWrapper>
+        <Separator/>
+        <USDAmountWrapper>
+          <Amount>
+            {dollarsExchangeRate ? `$${formatNum(dollars)}` : '?'}
+          </Amount>
+          <Denom>
+            USD
+          </Denom>
+        </USDAmountWrapper>
+      </CalculatedAmounts>
     </Wrapper>
   )
 }

--- a/gui/src/organisms/TokenReceiveAmountDisplay.tsx
+++ b/gui/src/organisms/TokenReceiveAmountDisplay.tsx
@@ -8,7 +8,7 @@ interface IProps {
   type: string,
   amount: number,
   dollarsExchangeRate?: number | null,
-  receiveExchangeRate?: number,
+  receiveExchangeRate?: number | null,
   receiveType: string,
 }
 
@@ -21,8 +21,8 @@ export const TokenReceiveAmountDisplay = ({
 }: IProps) => {
   const tokenData = tokens[type]
   const receiveTokenData = tokens[receiveType]
-  const dollars = dollarsExchangeRate ? receiveExchangeRate * dollarsExchangeRate * amount : 0
-  const receiveAmount = receiveExchangeRate * amount
+  const dollars = dollarsExchangeRate ? (receiveExchangeRate || 1) * dollarsExchangeRate * amount : 0
+  const receiveAmount = (receiveExchangeRate || 0) * amount
 
   return (
     <Wrapper>
@@ -37,7 +37,7 @@ export const TokenReceiveAmountDisplay = ({
             <TokenAmounts>
               {formatNum(amount, 4)} {tokenData.denom}
               {' '}={' '}
-              {formatNum(receiveAmount, 4)} {receiveTokenData.denom}
+              {receiveExchangeRate === null ? '?' : formatNum(receiveAmount, 4)} {receiveTokenData.denom}
             </TokenAmounts>
           )}
         </TokenInfo>

--- a/gui/src/organisms/TradeHistory/View.tsx
+++ b/gui/src/organisms/TradeHistory/View.tsx
@@ -2,7 +2,7 @@ import { observer } from 'mobx-react'
 import * as React from 'react'
 import styled from 'styled-components'
 import { formatNum } from 'thorchain-info-common/build/helpers/formatNum'
-import { ITrade } from '../../store/Store'
+import { ITrade } from '../../store/Trade'
 
 interface IProps {
   trades: ITrade[]

--- a/gui/src/store/Coin.ts
+++ b/gui/src/store/Coin.ts
@@ -1,0 +1,8 @@
+import { Instance, types } from 'mobx-state-tree'
+
+export const Coin = types.model({
+  amount: types.string,
+  denom: types.string,
+})
+
+export interface ICoin extends Instance<typeof Coin> {}

--- a/gui/src/store/Order.ts
+++ b/gui/src/store/Order.ts
@@ -1,0 +1,11 @@
+import { Instance, types } from 'mobx-state-tree'
+import { Coin } from './Coin'
+
+export const Order = types.model({
+  amount: Coin,
+  kind: types.number,
+  order_id: types.identifier,
+  price: Coin,
+})
+
+export interface IOrder extends Instance<typeof Order> {}

--- a/gui/src/store/Orderbook.ts
+++ b/gui/src/store/Orderbook.ts
@@ -1,0 +1,11 @@
+import { Instance, types } from 'mobx-state-tree'
+import { Order } from './Order'
+
+export const Orderbook = types.model({
+  amountDenom: types.string,
+  kind: types.number,
+  orders: types.maybeNull(types.array(Order)),
+  priceDenom: types.string,
+})
+
+export interface IOrderbook extends Instance<typeof Orderbook> {}

--- a/gui/src/store/Pair.ts
+++ b/gui/src/store/Pair.ts
@@ -1,0 +1,57 @@
+import { cast, flow, Instance, types } from 'mobx-state-tree'
+import { IExchangePair } from 'thorchain-info-common/src/interfaces/metrics'
+import { env } from '../helpers/env'
+import { http } from '../helpers/http'
+import { Orderbook } from './Orderbook'
+import { PairOHLCV } from './PairOHLCV'
+import { Trade } from './Trade'
+
+export const Pair = types.model({
+  amountDenom: types.string,
+  buyOrderbook: types.maybeNull(Orderbook),
+  id: types.identifier,
+  ohlcv: types.maybeNull(PairOHLCV),
+  priceDenom: types.string,
+  sellOrderbook: types.maybeNull(Orderbook),
+  trades: types.maybeNull(types.array(Trade)),
+})
+.actions(self => ({
+  fetchOhlcv: flow(function* fetchOhlcv() {
+    try {
+      const result: IExchangePair = yield http.get(
+        env.REACT_APP_API_HOST + `/exchange/pair/${self.priceDenom}/${self.amountDenom}`)
+      self.ohlcv = cast(result)
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.error(`Failed to fetch pair ${self.amountDenom}/${self.priceDenom}`, error)
+    }
+  }),
+  fetchOrderboks: flow(function* fetchOrderboks() {
+    try {
+      const [buyOrderbook, sellOrderbook] = yield Promise.all([
+        http.post(env.REACT_APP_LCD_API_HOST + '/exchange/query-order-book',
+          { kind: 'buy', amount_denom: self.amountDenom, price_denom: self.priceDenom }),
+        http.post(env.REACT_APP_LCD_API_HOST + '/exchange/query-order-book',
+          { kind: 'sell', amount_denom: self.amountDenom, price_denom: self.priceDenom }),
+      ])
+
+      self.buyOrderbook = cast(buyOrderbook)
+      self.sellOrderbook = cast(sellOrderbook)
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.error(`Failed to fetch orderbooks for ${self.amountDenom}/${self.priceDenom}`, error)
+    }
+  }),
+  fetchTrades: flow(function* fetchTrades() {
+    try {
+      const result: IExchangePair = yield http.get(
+        env.REACT_APP_API_HOST + `/exchange/trades/${self.priceDenom}/${self.amountDenom}`)
+      self.trades = cast(result)
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.error(`Failed to fetch trades ${self.amountDenom}/${self.priceDenom}`, error)
+    }
+  }),
+}))
+
+export interface IPair extends Instance<typeof Pair> {}

--- a/gui/src/store/PairOHLCV.ts
+++ b/gui/src/store/PairOHLCV.ts
@@ -1,0 +1,26 @@
+import { Instance, types } from 'mobx-state-tree'
+
+// variable names in this model are in line with TradingView:
+// c: closing price
+// h: highest price
+// l: lowest price
+// o: opening price
+// v: volume
+export const PairOHLCV = types.model({
+  c: types.number,
+  h: types.number,
+  l: types.number,
+  o: types.number,
+  v: types.number,
+})
+.views(self => ({
+  get change () {
+    return self.c - self.o
+  },
+  get changePercent () {
+    if (self.o === 0) { return 0 }
+    return (self.c - self.o) / self.o
+  },
+}))
+
+export interface IPairOHLCV extends Instance<typeof PairOHLCV> {}

--- a/gui/src/store/Price.ts
+++ b/gui/src/store/Price.ts
@@ -1,0 +1,8 @@
+import { Instance, types } from 'mobx-state-tree'
+
+export const Price = types.model({
+  price: types.number,
+  symbol: types.string,
+})
+
+export interface IPrice extends Instance<typeof Price> {}

--- a/gui/src/store/Store.ts
+++ b/gui/src/store/Store.ts
@@ -118,6 +118,40 @@ export const Store = types.model({
       console.error(`Failed to fetch prices`, error)
     }
   }),
+  getTokenExchangeRate(exchangeDenom: string, receiveDenom: string) {
+    const CLPs = self.clps
+
+    if (!CLPs) {
+      return null
+    }
+
+    let exchangeToRUNE = null
+    let RUNEToReceive = null
+
+    if (exchangeDenom === 'RUNE') {
+      exchangeToRUNE = 1
+    }
+
+    if (receiveDenom === 'RUNE') {
+      RUNEToReceive = 1
+    }
+
+    for (const CLP of CLPs) {
+      if (CLP.denom === exchangeDenom) {
+        exchangeToRUNE = CLP.price
+      }
+
+      if (CLP.denom === receiveDenom) {
+        RUNEToReceive = (1 / CLP.price)
+      }
+    }
+
+    if (exchangeToRUNE === null || RUNEToReceive === null) {
+      return null
+    }
+
+    return exchangeToRUNE * RUNEToReceive
+  },
   getTokenPriceInUsdt(amount: number, denom: string) {
     const pricesData = self.prices
 

--- a/gui/src/store/Store.ts
+++ b/gui/src/store/Store.ts
@@ -291,7 +291,8 @@ export const Store = types.model({
       self.pairSelected.fetchTrades()
     }
 
-    setInterval(fetch, 1000)
+    // TODO uncomment this
+    // setInterval(fetch, 1000)
 
     fetch()
   },

--- a/gui/src/store/Store.ts
+++ b/gui/src/store/Store.ts
@@ -1,161 +1,15 @@
 import { cast, flow, Instance, SnapshotIn, SnapshotOut, types } from 'mobx-state-tree'
-import { IExchangePair } from 'thorchain-info-common/src/interfaces/metrics'
 import { downloadFile } from '../helpers/downloadFile'
 import { env } from '../helpers/env'
 import { http } from '../helpers/http'
 import { loadThorchainClient } from '../helpers/loadThorchainClient'
-
-const Coin = types.model({
-  amount: types.string,
-  denom: types.string,
-})
-
-export interface ICoin extends Instance<typeof Coin> {}
-
-const Order = types.model({
-  amount: Coin,
-  kind: types.number,
-  order_id: types.identifier,
-  price: Coin,
-})
-
-export interface IOrder extends Instance<typeof Order> {}
-
-const Orderbook = types.model({
-  amountDenom: types.string,
-  kind: types.number,
-  orders: types.maybeNull(types.array(Order)),
-  priceDenom: types.string,
-})
-
-export interface IOrderbook extends Instance<typeof Orderbook> {}
-
-const Trade = types.model({
-  amount: types.number,
-  price: types.number,
-})
-.views(self => ({
-  get key () {
-    return self.amount + '/' + self.price
-  },
-  get volume () {
-    return self.amount * self.price
-  },
-}))
-
-export interface ITrade extends Instance<typeof Trade> {}
-
-// variable names in this model are in line with TradingView:
-// c: closing price
-// h: highest price
-// l: lowest price
-// o: opening price
-// v: volume
-const PairOHLCV = types.model({
-  c: types.number,
-  h: types.number,
-  l: types.number,
-  o: types.number,
-  v: types.number,
-})
-.views(self => ({
-  get change () {
-    return self.c - self.o
-  },
-  get changePercent () {
-    if (self.o === 0) { return 0 }
-    return (self.c - self.o) / self.o
-  },
-}))
-
-export interface IPairOHLCV extends Instance<typeof PairOHLCV> {}
-
-const Pair = types.model({
-  amountDenom: types.string,
-  buyOrderbook: types.maybeNull(Orderbook),
-  id: types.identifier,
-  ohlcv: types.maybeNull(PairOHLCV),
-  priceDenom: types.string,
-  sellOrderbook: types.maybeNull(Orderbook),
-  trades: types.maybeNull(types.array(Trade)),
-})
-.actions(self => ({
-  fetchOhlcv: flow(function* fetchOhlcv() {
-    try {
-      const result: IExchangePair = yield http.get(
-        env.REACT_APP_API_HOST + `/exchange/pair/${self.priceDenom}/${self.amountDenom}`)
-      self.ohlcv = cast(result)
-    } catch (error) {
-      // tslint:disable-next-line:no-console
-      console.error(`Failed to fetch pair ${self.amountDenom}/${self.priceDenom}`, error)
-    }
-  }),
-  fetchOrderboks: flow(function* fetchOrderboks() {
-    try {
-      const [buyOrderbook, sellOrderbook] = yield Promise.all([
-        http.post(env.REACT_APP_LCD_API_HOST + '/exchange/query-order-book',
-          { kind: 'buy', amount_denom: self.amountDenom, price_denom: self.priceDenom }),
-        http.post(env.REACT_APP_LCD_API_HOST + '/exchange/query-order-book',
-          { kind: 'sell', amount_denom: self.amountDenom, price_denom: self.priceDenom }),
-      ])
-
-      self.buyOrderbook = cast(buyOrderbook)
-      self.sellOrderbook = cast(sellOrderbook)
-    } catch (error) {
-      // tslint:disable-next-line:no-console
-      console.error(`Failed to fetch orderbooks for ${self.amountDenom}/${self.priceDenom}`, error)
-    }
-  }),
-  fetchTrades: flow(function* fetchTrades() {
-    try {
-      const result: IExchangePair = yield http.get(
-        env.REACT_APP_API_HOST + `/exchange/trades/${self.priceDenom}/${self.amountDenom}`)
-      self.trades = cast(result)
-    } catch (error) {
-      // tslint:disable-next-line:no-console
-      console.error(`Failed to fetch trades ${self.amountDenom}/${self.priceDenom}`, error)
-    }
-  }),
-}))
-
-export interface IPair extends Instance<typeof Pair> {}
-
-
-const Price = types.model({
-  price: types.number,
-  symbol: types.string,
-})
-
-export interface IPrice extends Instance<typeof Price> {}
-
-const Wallet = types.model({
-  address: types.string,
-  coins: types.array(Coin),
-  privateKey: types.string,
-  publicKey: types.string,
-})
-.actions(self => ({
-  fetchCoins: flow(function* fetchCoins() {
-    try {
-      const account: any = yield http.get(
-        `${env.REACT_APP_LCD_API_HOST}/accounts/${self.address}`,
-      )
-
-      if (!account) {
-        return
-      }
-
-      self.coins = cast(account.value.coins)
-    } catch (error) {
-      // tslint:disable-next-line:no-console
-      console.error(`Failed to fetch wallet coins`, error)
-    }
-  }),
-}))
-
-export interface IWallet extends Instance<typeof Wallet> {}
+import { IPair, Pair } from './Pair'
+import { IPrice, Price } from './Price'
+import { TradingPool } from './TradingPool'
+import { Wallet } from './Wallet'
 
 export const Store = types.model({
+  clps: types.array(TradingPool),
   pairSelected: types.reference(Pair),
   pairs: types.array(Pair),
   prices: types.array(Price),
@@ -230,6 +84,29 @@ export const Store = types.model({
       console.error(`Failed to load wallet from localstorage`, error)
     }
   },
+  fetchCLPs: flow(function* fetchCLPs() {
+    try {
+      const clps: [any] = yield http.get(
+        `${env.REACT_APP_LCD_API_HOST}/clps`,
+      )
+      self.clps = cast(clps.map(pool => ({
+        accountAddress: pool.clp.account_address,
+        creator: pool.clp.creator,
+        currentSupply: Number(pool.clp.currentSupply),
+        decimals: pool.clp.decimals,
+        denom: pool.clp.ticker,
+        denomAmount: pool.account[pool.clp.ticker],
+        initialSupply: Number(pool.clp.initialSupply),
+        name: pool.clp.name,
+        price: pool.account.price,
+        reserveRatio: Number(pool.clp.reserveRatio),
+        runeAmount: pool.account.RUNE,
+      })))
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.error(`Failed to fetch CLPs`, error)
+    }
+  }),
   fetchPrices: flow(function* fetchPrices() {
     try {
       const prices: [IPrice] = yield http.get(
@@ -291,8 +168,7 @@ export const Store = types.model({
       self.pairSelected.fetchTrades()
     }
 
-    // TODO uncomment this
-    // setInterval(fetch, 1000)
+    setInterval(fetch, 1000)
 
     fetch()
   },

--- a/gui/src/store/Trade.ts
+++ b/gui/src/store/Trade.ts
@@ -1,0 +1,16 @@
+import { Instance, types } from 'mobx-state-tree'
+
+export const Trade = types.model({
+  amount: types.number,
+  price: types.number,
+})
+.views(self => ({
+  get key () {
+    return self.amount + '/' + self.price
+  },
+  get volume () {
+    return self.amount * self.price
+  },
+}))
+
+export interface ITrade extends Instance<typeof Trade> {}

--- a/gui/src/store/TradingPool.ts
+++ b/gui/src/store/TradingPool.ts
@@ -1,0 +1,17 @@
+import { Instance, types } from 'mobx-state-tree'
+
+export const TradingPool  = types.model({
+  accountAddress: types.string, // original: account_address
+  creator: types.string,
+  currentSupply: types.number, // original: is string
+  decimals: types.number,
+  denom: types.string, // original: ticker
+  denomAmount: types.number, // original: XRP, etc (denom)
+  initialSupply: types.number, // original: is string
+  name: types.string,
+  price: types.number,
+  reserveRatio: types.number, // original: is string
+  runeAmount: types.number, // original: RUNE
+})
+
+export interface ITradingPool extends Instance<typeof TradingPool> {}

--- a/gui/src/store/Wallet.ts
+++ b/gui/src/store/Wallet.ts
@@ -1,0 +1,31 @@
+import { cast, flow, Instance, types } from 'mobx-state-tree'
+import { env } from '../helpers/env'
+import { http } from '../helpers/http'
+import { Coin } from './Coin'
+
+export const Wallet = types.model({
+  address: types.string,
+  coins: types.array(Coin),
+  privateKey: types.string,
+  publicKey: types.string,
+})
+.actions(self => ({
+  fetchCoins: flow(function* fetchCoins() {
+    try {
+      const account: any = yield http.get(
+        `${env.REACT_APP_LCD_API_HOST}/accounts/${self.address}`,
+      )
+
+      if (!account) {
+        return
+      }
+
+      self.coins = cast(account.value.coins)
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.error(`Failed to fetch wallet coins`, error)
+    }
+  }),
+}))
+
+export interface IWallet extends Instance<typeof Wallet> {}


### PR DESCRIPTION
- Add missing tokens, extend Coin component to display placeholders for token images we don't have yet. 
- Hook up CLPs to the swap page. 
- Refactored Store into a bunch of smaller files. 
- Hook up prices of CLPs up so that you can see the accurate exchange rate of one token to another.

Only thing remaining: actually executing the swaps. Might need your help on that @philipstanislaus.