### PR TITLE
Execute swap

### DIFF
--- a/gui/public/global.css
+++ b/gui/public/global.css
@@ -1,7 +1,0 @@
-/* Some globally-set CSS for font-display purposes */
-body {
-    font-family: 'Open Sans', Helvetica, Arial, sans-serif;
-    font-size: 14px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}

--- a/gui/public/index.html
+++ b/gui/public/index.html
@@ -15,7 +15,6 @@
     <script src="%PUBLIC_URL%/datafeeds/udf/dist/polyfills.js"></script>
     <script src="%PUBLIC_URL%/datafeeds/udf/dist/bundle.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Exo+2:500|Open+Sans:400,600" rel="stylesheet">
-    <link href="%PUBLIC_URL%/global.css" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -1,7 +1,10 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
   color: white;
   background-color: #101921;
+  font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/gui/src/organisms/TokenExchangeAmountDisplay.tsx
+++ b/gui/src/organisms/TokenExchangeAmountDisplay.tsx
@@ -76,12 +76,12 @@ export class TokenExchangeAmountDisplay extends React.Component<IProps, IState> 
     totalExchangeAmount = Math.min(Number.isNaN(totalExchangeAmount) ? 0 : totalExchangeAmount, maxExchangeAmount)
     const selectedPercentage = Math.round((totalExchangeAmount / maxExchangeAmount) * 100)
 
-    if (onTotalAmountChange) {
-      onTotalAmountChange(totalExchangeAmount)
-    }
-
     if (onPercentageSelectClick) {
       onPercentageSelectClick(selectedPercentage)
+    }
+
+    if (onTotalAmountChange) {
+      onTotalAmountChange(totalExchangeAmount)
     }
 
     this.setState({

--- a/gui/src/store/Store.ts
+++ b/gui/src/store/Store.ts
@@ -157,34 +157,27 @@ export const Store = types.model({
   },
   getTokenPriceInUsdt(amount: number, denom: string) {
     const pricesData = self.prices
+    const CLPs = self.clps
 
-    if (!pricesData) {
+    if (!pricesData || !CLPs) {
       return null
     }
 
-    let BTCtoUSDT
-    let denomToBTC
-
-    if (denom === 'USDT') {
-      return amount
-    }
+    // - Get ETH price in USDT from Binance
+    // - Set RUNE price in USDT from ETH:RUNE CLP
+    // - Set all other prices in RUNE and USDT from TOKEN:RUNE CLP
+    const DenomToRUNE = this.getTokenExchangeRate(denom, 'RUNE')
+    const RUNEtoETH = this.getTokenExchangeRate('RUNE', 'ETH')
+    let ETHtoUSDT
 
     for (const price of pricesData) {
-      if (price.symbol === `${denom}USDT`) {
-        return amount * price.price
-      }
-
-      if (price.symbol === `${denom}BTC`) {
-        denomToBTC = price.price
-      }
-
-      if (price.symbol === 'BTCUSDT') {
-        BTCtoUSDT = price.price
+      if (price.symbol === `ETHUSDT`) {
+        ETHtoUSDT = price.price
       }
     }
 
-    if (BTCtoUSDT && denomToBTC) {
-      return amount * denomToBTC * BTCtoUSDT
+    if (RUNEtoETH && ETHtoUSDT && DenomToRUNE) {
+      return amount * DenomToRUNE * RUNEtoETH * ETHtoUSDT
     }
 
     return null

--- a/gui/src/store/Store.ts
+++ b/gui/src/store/Store.ts
@@ -198,6 +198,39 @@ export const Store = types.model({
       console.error(`Failed to load up thorchain client`, error)
     }
   }),
+  signAndBroadcastClpTradeTx: flow(function* signAndBroadcastClpTradeTx(
+    fromTicker: string, toTicker: string, fromAmount: number,
+  ) {
+    const { wallet } = self
+    if (!wallet) {
+      throw new Error('Wallet not loaded')
+    }
+
+    const sender = wallet.address
+    const { accountNumber, sequence } = yield wallet.fetchLatestAccountNumberAndSequence()
+    const txContext = {
+      account_number: accountNumber,
+      chain_id: env.REACT_APP_CHAIN_ID,
+      fee: '',
+      gas: 20000,
+      memo: '',
+      priv_key: wallet.privateKey,
+      sequence,
+    }
+
+    const { client }: IClient = yield loadThorchainClient()
+
+    const res = yield client.signAndBroadcastClpTradeTx(txContext, sender, fromTicker, toTicker, fromAmount)
+
+    if (res.result.check_tx.code || res.result.deliver_tx.code) {
+      throw new Error(`Unknown error committing tx, result: ${JSON.stringify(res.result)}`)
+    }
+
+    return {
+      height: res.result.height,
+      isOk: true,
+    }
+  }),
   signAndBroadcastExchangeCreateLimitOrderTx: flow(function* signAndBroadcastExchangeCreateLimitOrderTx(
     kind: 'buy' | 'sell', amount: string, price: string,
   ) {


### PR DESCRIPTION
Big thing here: Actually execute swap when swap button is clicked.

Other changes:
- Consolidate globally-used CSS. 
- Refresh CLP prices every 5 seconds. 
- Fix subtle bug with total swap amount.
- Modify getTokenPriceInUsdt so that it's mostly internally-priced via CLP, minus one external tether to Ether, through Binance's ETH price

Note: @philipstanislaus, I wasn't actually able to test executing the swap against the test net, didn't have any RUNE to play with. Will need your help there. Also, not 100% sure I've used the `client.signAndBroadcastClpTradeTx` function correctly.