### PR TITLE
Nginx config fix

### DIFF
--- a/deployment/ansible/roles/nginx/templates/app.nginx.conf.j2
+++ b/deployment/ansible/roles/nginx/templates/app.nginx.conf.j2
@@ -78,7 +78,7 @@ server {
   }
 
   location / {
-    try_files /index.html =404;
+    try_files $uri /index.html =404;
     include helpers/doNotCache.nginx.conf;
   }
 }


### PR DESCRIPTION
This should fix the issue we were seeing where the TradingView html file wasn't being served up in its iFrame, and instead the Asgardex index.html file was being loaded instead.