### PR TITLE
Swap confirmation + hide private key

### DIFF
--- a/gui/src/atoms/Alert.tsx
+++ b/gui/src/atoms/Alert.tsx
@@ -1,6 +1,23 @@
+import * as React from 'react'
 import styled from 'styled-components'
 
-export const Alert = styled.div<{ color?: 'success' | 'danger' }>`
+interface IProps {
+  color?: 'success' | 'danger',
+  children?: any,
+  onDismiss?: () => void,
+  style?: any,
+}
+
+export const Alert = ({ color, style, children, onDismiss }: IProps) => (
+  <AlertWrapper>
+    <BaseAlert color={color} style={style}>{children}</BaseAlert>
+    {onDismiss && (
+      <DismissButton onClick={onDismiss}>X</DismissButton>
+    )}
+  </AlertWrapper>
+)
+
+export const BaseAlert = styled.div<{ color?: 'success' | 'danger' }>`
   margin-top: 22px;
   font-family: 'Helvetica';
   font-size: 15px;
@@ -8,4 +25,23 @@ export const Alert = styled.div<{ color?: 'success' | 'danger' }>`
   border-radius: 5px;
   color: #ffffff;
   padding: 22px;
+`
+
+const AlertWrapper = styled.div`
+  position: relative;
+`
+
+const DismissButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #fff;
+  position: absolute;
+  right: 15px;
+  top: 18px;
+  height: 24px;
+  width: 24px;
+  text-align: center;
+  font-size: 14px;
+  padding: 0;
+  cursor: pointer;
 `

--- a/gui/src/organisms/AccountSetup.tsx
+++ b/gui/src/organisms/AccountSetup.tsx
@@ -2,6 +2,7 @@ import { inject, observer } from 'mobx-react'
 import * as React from 'react'
 import styled from 'styled-components'
 import { formatNum } from 'thorchain-info-common/build/helpers/formatNum'
+import { Alert } from '../atoms/Alert'
 import { Button } from '../atoms/Button'
 import { Col } from '../atoms/Col'
 import { Header } from '../atoms/Header'
@@ -16,7 +17,8 @@ interface IProps {
 }
 
 interface IState {
-  privateKey: string
+  privateKey: string,
+  walletWasCreated: boolean
 }
 
 @inject('store')
@@ -25,6 +27,7 @@ export class AccountSetup extends React.Component<IProps, IState> {
 
   public state = {
     privateKey: '',
+    walletWasCreated: false,
   }
 
   private fileInputRef: any
@@ -33,6 +36,9 @@ export class AccountSetup extends React.Component<IProps, IState> {
     const { store } = this.props
     store!.createWallet()
     this.clearPrivateKeyState()
+    this.setState({
+      walletWasCreated: true,
+    })
   }
 
   public handleForgetAccountClick = () => {
@@ -84,8 +90,15 @@ export class AccountSetup extends React.Component<IProps, IState> {
     })
   }
 
+  public dismissPrivateKeyMessage = () => {
+    this.setState({
+      walletWasCreated: false,
+    })
+  }
+
   public render() {
     const { store } = this.props
+    const { walletWasCreated } = this.state
     const wallet = store!.wallet
     const walletErrorMessage = store!.ui.walletErrorMessage
 
@@ -95,9 +108,18 @@ export class AccountSetup extends React.Component<IProps, IState> {
         <Row>
           <Col>
             <Label>Token owner</Label>
+            {wallet && walletWasCreated && (
+              <Alert
+                color="success"
+                style={{ marginTop: 0, marginBottom: 20 }}
+                onDismiss={this.dismissPrivateKeyMessage}
+              >
+                Private key: {wallet.privateKey}
+              </Alert>
+            )}
             <Input
               placeholder="Enter your private key"
-              value={wallet ? wallet.privateKey : this.state.privateKey}
+              value={wallet ? '(Private key hidden)' : this.state.privateKey}
               disabled={Boolean(wallet)}
               onChange={this.handlePrivateKeyChange}
             />

--- a/gui/src/organisms/CreateSwap.tsx
+++ b/gui/src/organisms/CreateSwap.tsx
@@ -1,6 +1,7 @@
 import { inject, observer } from 'mobx-react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { Alert } from '../atoms/Alert'
 import { Button } from '../atoms/Button'
 import { Coin } from '../atoms/Coin'
 import { SearchInput } from '../atoms/SearchInput'
@@ -23,6 +24,7 @@ interface IState {
   selectedExchangePercentage: number,
   selectedExchangeToken: string | null,
   selectedReceiveToken: string | null,
+  showSwapSuccess: boolean,
   swapError: string | null,
   tokenSearchTerm: string,
   totalExchangeAmount: number,
@@ -37,6 +39,7 @@ export class CreateSwap extends React.Component<IProps, IState> {
     selectedExchangePercentage: 100,
     selectedExchangeToken: null,
     selectedReceiveToken: null,
+    showSwapSuccess: false,
     swapError: null,
     tokenSearchTerm: '',
     totalExchangeAmount: 0,
@@ -88,6 +91,12 @@ export class CreateSwap extends React.Component<IProps, IState> {
     })
   }
 
+  public handleSwapSuccessDismiss = () => {
+    this.setState({
+      showSwapSuccess: false,
+    })
+  }
+
   public handleSwapClick = () => {
     const {
       selectedExchangeToken,
@@ -121,6 +130,7 @@ export class CreateSwap extends React.Component<IProps, IState> {
     }).then(() => {
       this.setState({
         isSwapping: false,
+        showSwapSuccess: true,
       })
     }).catch((err) => {
       this.setState({
@@ -136,6 +146,7 @@ export class CreateSwap extends React.Component<IProps, IState> {
       selectedExchangePercentage,
       selectedExchangeToken,
       selectedReceiveToken,
+      showSwapSuccess,
       tokenSearchTerm,
       totalExchangeAmount,
       selectedExchangeAmount,
@@ -269,6 +280,11 @@ export class CreateSwap extends React.Component<IProps, IState> {
                 <SwapError>
                   {swapError}
                 </SwapError>
+              )}
+              {showSwapSuccess && (
+                <Alert color="success" onDismiss={this.handleSwapSuccessDismiss}>
+                  Swap executed successfully.
+                </Alert>
               )}
               <SwapButton
                 primary={true}


### PR DESCRIPTION
Add swap confirmation alert to the swap page. Add an alert of the private key when a wallet has been created on the account page. Hide private key in input field on the account page.